### PR TITLE
Added error description for delete function response

### DIFF
--- a/frontend/src/js/Backend.js
+++ b/frontend/src/js/Backend.js
@@ -58,11 +58,11 @@ class Backend {
             method: 'DELETE',
             credentials: 'include'
         };
-
         const respone = await fetch(path, arg)
-        // RESPONE IS EMPTY IN DELETE CASE
-        // if (!respone.ok) throw new Error(respone.statusText);
-        // return await respone.json()
+        
+        if (!respone.ok) {
+            throw new Error((await respone.json()).error) 
+        }
     }
 
     // AVATAR FUNCTIONS


### PR DESCRIPTION
A failed delete response can also have an error. E. g. the resource that the request is trying to delete doesn't exist or authentication fails, etc.