### PR TITLE
Renamed FriendStatsView to UserStatsView

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -52,9 +52,9 @@ const router = createRouter({
       component: () => import('../views/FriendsView.vue')
     },
     {
-      path: '/friends/:friendname',
-      name: 'friends/stats',
-      component: () => import('../views/FriendStatsView.vue'),
+      path: '/users/:nickname',
+      name: 'user/stats',
+      component: () => import('../views/UserStatsView.vue'),
       props: true
     },
     // TOURNAMENTS

--- a/frontend/src/views/FriendsView.vue
+++ b/frontend/src/views/FriendsView.vue
@@ -96,7 +96,7 @@ onMounted(() => {
 											/>
 										</td>
 										<td class="bg-light text-start align-middle">
-											<router-link :to="`/friends/${friend.nickname}`">{{friend.nickname}}</router-link>
+											<router-link :to="`/users/${friend.nickname}`">{{friend.nickname}}</router-link>
 										</td>
 										<td class="bg-light text-end align-middle">
 											<button type="button" class="btn btn-outline-danger" aria-label="Close" @click="openModal('DELETEFRIEND', friend)">X</button>

--- a/frontend/src/views/UserStatsView.vue
+++ b/frontend/src/views/UserStatsView.vue
@@ -15,7 +15,7 @@ const defeatsRatio = ref(null);
 const winsRatio = ref(null);
 
 // INDIVIDUAL FRIEND
-const friendname = ref('');
+const nickname = ref('');
 const route = useRoute();
 const friends = ref({});
 const friend = ref(null);
@@ -25,14 +25,14 @@ const avatar = ref(null);
 const isLoaded = ref(false);
 
 onMounted(() => {
-  friendname.value = route.params.friendname;
+  nickname.value = route.params.nickname;
   fetchData();
 });
 
 const fetchData = async() => {
   try {
     friends.value = await Backend.get(`/api/users/me/friends`);
-    friend.value = friends.value.find(friend => friend.nickname === friendname.value);
+    friend.value = friends.value.find(friend => friend.nickname === nickname.value);
     if(friend.value) {
       games.value = await Backend.get(`/api/users/${friend.value.id}/games`);
       avatar.value = await Avatar.getAvatarById(friend.value.id);


### PR DESCRIPTION
In the module **Standard user management, authentication, users across tournaments.**:
> User profiles display stats, such as wins and losses.

In the module **Live Chat**:
> The user should be able to access other players profiles through the chat interface

So the basic stats should be part of the user profile. Thats why I renamed it