### PR TITLE
Removed docker module from metricbeat config

### DIFF
--- a/elastic-stack/metricbeat.yml
+++ b/elastic-stack/metricbeat.yml
@@ -28,23 +28,8 @@ metricbeat.modules:
   password: ${ELASTIC_PASSWORD}
   xpack.enabled: true
 
-- module: docker
-  metricsets:
-    - "container"
-    - "cpu"
-    - "diskio"
-    - "healthcheck"
-    - "info"
-    #- "image"
-    - "memory"
-    - "network"
-  hosts: ["unix:///var/run/docker.sock"]
-  period: 10s
-  enabled: true
-
 processors:
   - add_host_metadata: ~
-  - add_docker_metadata: ~
 
 setup:
   dashboards.enabled: true


### PR DESCRIPTION
This module does not work anymore because we can't use the docker socket